### PR TITLE
Stop audio element from leaking outside of lessons

### DIFF
--- a/DuolingoReverseTreeEnhancer.user.js
+++ b/DuolingoReverseTreeEnhancer.user.js
@@ -299,6 +299,14 @@ function onChange() {
         tree.insertBefore(button, tree.firstChild);
         updateButton();
     }
+    
+    if (/slide-session-end/.test(newclass)) {
+        // End screen ("you beat the clock...").
+        // Destroy the reference to the audio object
+        // so that subsequent <S-Space> keypresses
+        // don't cause the audio to repeat in, e.g., the tree or discussions.
+        audio = null;
+    }
 
     if(newclass != oldclass){
         oldclass = newclass;


### PR DESCRIPTION
Summary:
The old behavior was that, even after you exit the lesson,
you can press `<S-Space>` to repeat the last spoken word.
This was really annoying for scrolling up in discussions
(using the normal `<Space>` to scroll down and `<S-Space>` to scroll up).
It could also happen when you just press the button by accident.

This patch fixes this behavior
by nullifying the reference to the audio when the lesson ends,
so that calls to `keyUpHandler` skip the conditional.

Test Plan:
Run through a timed practice,
and note that there are no more errors than usual.
Then press `<S-Space>` in silence to your heart's content.
