### PR TITLE
Prevent same audio from playing twice in certain situations

### DIFF
--- a/DuolingoReverseTreeEnhancer.user.js
+++ b/DuolingoReverseTreeEnhancer.user.js
@@ -104,16 +104,16 @@ function playSound(url) {
         url: url,
         autoLoad: true,
         onload: function() {
-            if(audio.readyState == 2){
-                displaySoundErrorBox(audio.url);
+            if(this.readyState == 2){
+                displaySoundErrorBox(this.url);
             } else if(!waiting){
-                audio.play();
+                this.play();
             }
         },
         onfinish: function () {
             if(waiting) {
                 waiting = false;
-                audio.play();
+                this.play();
             }
         }
     });


### PR DESCRIPTION
Sometimes if I answer a question where the audio plays after the answer (source -> target), and move on to the next question quickly, and that question plays audio straight away (target -> source), the audio for the new question will be played twice.

This pull request fixes that by referencing the current object rather than whatever is assigned to `audio` (which may change midway through a request for the last audio).

There's still the issue that sounds sometimes play over the top of each other in these situations, but that happened before as well.
